### PR TITLE
escape regex characters in swearwords

### DIFF
--- a/lib/profanity.js
+++ b/lib/profanity.js
@@ -21,7 +21,9 @@ var DEFAULT_REPLACEMENTS = [
     DEFAULT_REGEX = getListRegex(swearwords);
 
 function getListRegex (list) {
-    return new RegExp('\\b(' + list.join('|') + ')\\b', 'gi');
+  // we want to treat all characters in the word as literals, not as regex specials (e.g. shi+)
+  function escapeRegexChars(word) { return word.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'); };
+  return new RegExp('\\b(' + list.map(escapeRegexChars).join('|') + ')\\b', 'gi');
 }
 
 function check (target, forbiddenList) {


### PR DESCRIPTION
Some of the swearwords contain characters which have special meaning in regular expressions, this results in spurious matches.  For example "shi+" matches "shift".  This patch escapes the characters in the words before constructing the RegExp.